### PR TITLE
Add Host setter

### DIFF
--- a/doc/Overview/Hosting/HostingOverview.md
+++ b/doc/Overview/Hosting/HostingOverview.md
@@ -12,7 +12,7 @@ Hosting is delivered as a NuGet package [Microsoft.Extensions.Hosting.WinUI](htt
 Initialization of the `IHost` instance is done from the generated App.cs file of your solution. It should be created as soon as the application is launched. The following snippet uses the `CreateBuilder()` extension method to instantiate an `IApplicationBuilder` from your `Application`. It is then possible to configure the associated `IHostBuilder` to register services or use the numerous extensions offered by this library.
 
 ```csharp
-private IHost Host { get; }
+private IHost Host { get; set; }
 
 protected override void OnLaunched(LaunchActivatedEventArgs e)
 {
@@ -64,7 +64,7 @@ public class SimpleHostService : IHostedService
 The implementation can be registered during the host initialization by calling the `AddHostedService` method on the `IServiceCollection` returned by the `ConfigureServices` method on the `IHostBuilder`.
 
 ```csharp
-private IHost Host { get; }
+private IHost Host { get; set; }
 
 protected override void OnLaunched(LaunchActivatedEventArgs e)
 {
@@ -127,7 +127,7 @@ Debug.WriteLine($"Environment: {env.EnvironmentName}");
 The current hosting environment can be changed with the `UseEnvironment()` extension method.
 
 ```csharp
-private IHost Host { get; }
+private IHost Host { get; set; }
 
 protected override void OnLaunched(LaunchActivatedEventArgs e)
 {
@@ -144,7 +144,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs e)
 The current hosting environment can also be used when configuring the host builder.
 
 ```csharp
-private IHost Host { get; }
+private IHost Host { get; set; }
 
 protected override void OnLaunched(LaunchActivatedEventArgs e)
 {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Docs Bugfix

## What is the current behavior?

Build error

> Property or indexer 'App.Host' cannot be assigned to -- it is read only


## What is the new behavior?

Added setter because we would like to set this from `OnLaunched` and not from `ctor`


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
